### PR TITLE
change the mLab URL for db migrating purpose

### DIFF
--- a/app.js
+++ b/app.js
@@ -31,7 +31,7 @@ app.io = require('socket.io')();
 global.__base = __dirname + '/';
 
 //var mongoURI = process.env.MONGOLAB_URI || 'YOUR MONGODB CONNECTION ON mLAB';
-var mongoURI = process.env.MONGOLAB_URI || 'mongodb://admin:admin@ds061335.mongolab.com:61335/heroku_w9bxpzpc';
+var mongoURI = process.env.MONGOLAB_URI || 'mongodb://heroku_x4bz85sv:4btedcfpao88ohdbm8gnam8k72@ds151141.mlab.com:51141/heroku_x4bz85sv';
 console.log('Connecting to DB: ' + mongoURI);
 var db = monk(mongoURI);
 

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -2,7 +2,7 @@
  * Config var for app
 **/
 module.exports = {
-  mongoDBURI: process.env.MONGOLAB_URI || 'mongodb://admin:admin@ds061335.mongolab.com:61335/heroku_w9bxpzpc',
+  mongoDBURI: process.env.MONGOLAB_URI || 'mongodb://heroku_x4bz85sv:4btedcfpao88ohdbm8gnam8k72@ds151141.mlab.com:51141/heroku_x4bz85sv',
   port: process.env.PORT || 4941,
   secret: process.env.SECRET || 'mysecret'
 };


### PR DESCRIPTION
URL for the MongoDB server has been updated to point to our own exclusive repository. We have moved the info from the shared db to our own now.